### PR TITLE
Fix car not showing after crossing boundary

### DIFF
--- a/src/main/java/nl/hanyeager/sander/entities/CyberCar.java
+++ b/src/main/java/nl/hanyeager/sander/entities/CyberCar.java
@@ -23,7 +23,7 @@ public class CyberCar extends DynamicSpriteEntity implements SceneBorderCrossing
     public void notifyBoundaryCrossing(SceneBorder sceneBorder) {
         switch (direction) {
             case LEFT -> setAnchorLocationX(getSceneWidth());
-            case RIGHT -> setAnchorLocationX(-size.width());
+            case RIGHT -> setAnchorLocationX(-size.width() + 25.0); // Quick fix for cars not displaying on screen after crossing boundary
         }
         setAnchorLocationY(new Random().nextInt((int) getSceneHeight()- (int)size.height()));
         //System.out.println(new Random().nextInt((int) getSceneHeight()- (int)size.height()));

--- a/src/main/java/nl/hanyeager/sander/scenes/GameLevel.java
+++ b/src/main/java/nl/hanyeager/sander/scenes/GameLevel.java
@@ -16,7 +16,7 @@ public class GameLevel extends DynamicScene {
 
     @Override
     public void setupEntities() {
-        addEntity(new CyberCar("sprites/ship-01.png", new Coordinate2D(350, 350), Direction.RIGHT, new Size(125, 76)));
-        addEntity(new CyberCar("sprites/ship-02.png", new Coordinate2D(350, 350), Direction.LEFT, new Size(125, 76)));
+        addEntity(new CyberCar("sprites/ship-01.png", new Coordinate2D(350, 350), Direction.LEFT, new Size(125, 76)));
+        addEntity(new CyberCar("sprites/ship-02.png", new Coordinate2D(350, 350), Direction.RIGHT, new Size(125, 76)));
     }
 }


### PR DESCRIPTION
Fixed a bug where the car would not be anchored right on the screen when it crossed a boundary